### PR TITLE
changed boiler room assets in unity inspector

### DIFF
--- a/ChillerUnityProject/Assets/Scenes/BoilerRoom.unity
+++ b/ChillerUnityProject/Assets/Scenes/BoilerRoom.unity
@@ -214,7 +214,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 424810659}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 291, y: 124, z: 0}
+  m_LocalPosition: {x: 270.9, y: 95.7, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1841096905}
@@ -238,7 +238,7 @@ BoxCollider2D:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
     oldSize: {x: 200, y: 200}
-    newSize: {x: 1.859375, y: 2.0390625}
+    newSize: {x: 200, y: 200}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
     adaptiveTiling: 0
@@ -285,12 +285,12 @@ SpriteRenderer:
   m_SortingLayerID: 1278940923
   m_SortingLayer: 2
   m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 7e049227798e5f649a237b74fd7490ad, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 9ab0ac89dac16fd438722c6905d768cb, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 1.859375, y: 2.0390625}
+  m_Size: {x: 200, y: 200}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
@@ -438,7 +438,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 583864101}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -449, y: -126, z: 0}
+  m_LocalPosition: {x: -450.3, y: -106.8, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1841096905}
@@ -490,7 +490,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 57.55733}
+  m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -876,12 +876,12 @@ PrefabInstance:
     - target: {fileID: 8379568840493700252, guid: cb80c6c1c567d3f488087444e79936c2,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -6
+      value: -4.9
       objectReference: {fileID: 0}
     - target: {fileID: 8379568840493700252, guid: cb80c6c1c567d3f488087444e79936c2,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -105
+      value: -87
       objectReference: {fileID: 0}
     - target: {fileID: 8379568840493700252, guid: cb80c6c1c567d3f488087444e79936c2,
         type: 3}
@@ -928,6 +928,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: finalPuzzle
       objectReference: {fileID: 0}
+    - target: {fileID: 8379568840493700255, guid: cb80c6c1c567d3f488087444e79936c2,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cb80c6c1c567d3f488087444e79936c2, type: 3}
 --- !u!4 &1287691005 stripped
@@ -951,7 +956,7 @@ PrefabInstance:
     - target: {fileID: 8379568840493700252, guid: 66cec47f981f32e43a99aeb928dc59a9,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -362
+      value: -359.9
       objectReference: {fileID: 0}
     - target: {fileID: 8379568840493700252, guid: 66cec47f981f32e43a99aeb928dc59a9,
         type: 3}
@@ -1003,6 +1008,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: introPuzzle
       objectReference: {fileID: 0}
+    - target: {fileID: 8379568840493700255, guid: 66cec47f981f32e43a99aeb928dc59a9,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 66cec47f981f32e43a99aeb928dc59a9, type: 3}
 --- !u!4 &1462736283 stripped
@@ -1182,12 +1192,12 @@ PrefabInstance:
     - target: {fileID: 3253824832891022335, guid: 35fd143d373caf2419a151bbd5e9d661,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 295
+      value: 281
       objectReference: {fileID: 0}
     - target: {fileID: 3253824832891022335, guid: 35fd143d373caf2419a151bbd5e9d661,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 152
+      value: 123.2
       objectReference: {fileID: 0}
     - target: {fileID: 3253824832891022335, guid: 35fd143d373caf2419a151bbd5e9d661,
         type: 3}
@@ -1295,12 +1305,12 @@ PrefabInstance:
     - target: {fileID: 8379568840493700252, guid: 68e7e748572c0f249b7806b42f17aedb,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 391
+      value: 388.1
       objectReference: {fileID: 0}
     - target: {fileID: 8379568840493700252, guid: 68e7e748572c0f249b7806b42f17aedb,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -121
+      value: -105.9
       objectReference: {fileID: 0}
     - target: {fileID: 8379568840493700252, guid: 68e7e748572c0f249b7806b42f17aedb,
         type: 3}
@@ -1347,6 +1357,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: intermediatePuzzle
       objectReference: {fileID: 0}
+    - target: {fileID: 8379568840493700255, guid: 68e7e748572c0f249b7806b42f17aedb,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 68e7e748572c0f249b7806b42f17aedb, type: 3}
 --- !u!4 &1956737272 stripped

--- a/ChillerUnityProject/Assets/Sprites/boilerRoom/Boiler.png.meta
+++ b/ChillerUnityProject/Assets/Sprites/boilerRoom/Boiler.png.meta
@@ -31,7 +31,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: -1
+    filterMode: 0
     aniso: -1
     mipBias: -100
     wrapU: 1
@@ -42,7 +42,7 @@ TextureImporter:
   compressionQuality: 50
   spriteMode: 1
   spriteExtrude: 1
-  spriteMeshType: 1
+  spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 1
@@ -64,7 +64,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -76,7 +76,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0

--- a/ChillerUnityProject/Assets/Sprites/boilerRoom/BoilerRoomBackground.png.meta
+++ b/ChillerUnityProject/Assets/Sprites/boilerRoom/BoilerRoomBackground.png.meta
@@ -31,7 +31,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: -1
+    filterMode: 0
     aniso: -1
     mipBias: -100
     wrapU: 1
@@ -42,7 +42,7 @@ TextureImporter:
   compressionQuality: 50
   spriteMode: 1
   spriteExtrude: 1
-  spriteMeshType: 1
+  spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 1
@@ -64,7 +64,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -76,7 +76,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0

--- a/ChillerUnityProject/Assets/Sprites/boilerRoom/Door.png.meta
+++ b/ChillerUnityProject/Assets/Sprites/boilerRoom/Door.png.meta
@@ -31,7 +31,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: -1
+    filterMode: 0
     aniso: -1
     mipBias: -100
     wrapU: 1
@@ -42,7 +42,7 @@ TextureImporter:
   compressionQuality: 50
   spriteMode: 1
   spriteExtrude: 1
-  spriteMeshType: 1
+  spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 1
@@ -64,7 +64,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -76,7 +76,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0

--- a/ChillerUnityProject/Assets/Sprites/boilerRoom/LoreNote.png.meta
+++ b/ChillerUnityProject/Assets/Sprites/boilerRoom/LoreNote.png.meta
@@ -31,7 +31,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: -1
+    filterMode: 0
     aniso: -1
     mipBias: -100
     wrapU: 1
@@ -42,7 +42,7 @@ TextureImporter:
   compressionQuality: 50
   spriteMode: 1
   spriteExtrude: 1
-  spriteMeshType: 1
+  spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 1
@@ -64,7 +64,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -76,7 +76,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0

--- a/ChillerUnityProject/Assets/Sprites/boilerRoom/LoreTable.png.meta
+++ b/ChillerUnityProject/Assets/Sprites/boilerRoom/LoreTable.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7e049227798e5f649a237b74fd7490ad
+guid: 9ab0ac89dac16fd438722c6905d768cb
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -31,7 +31,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: -1
+    filterMode: 0
     aniso: -1
     mipBias: -100
     wrapU: 1
@@ -42,7 +42,7 @@ TextureImporter:
   compressionQuality: 50
   spriteMode: 1
   spriteExtrude: 1
-  spriteMeshType: 1
+  spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 1
@@ -64,7 +64,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -76,7 +76,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0

--- a/ChillerUnityProject/Assets/Sprites/boilerRoom/Pipes_1.png.meta
+++ b/ChillerUnityProject/Assets/Sprites/boilerRoom/Pipes_1.png.meta
@@ -31,7 +31,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: -1
+    filterMode: 0
     aniso: -1
     mipBias: -100
     wrapU: 1
@@ -42,7 +42,7 @@ TextureImporter:
   compressionQuality: 50
   spriteMode: 1
   spriteExtrude: 1
-  spriteMeshType: 1
+  spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 1
@@ -64,7 +64,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -76,7 +76,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0

--- a/ChillerUnityProject/Assets/Sprites/boilerRoom/Pipes_2.png.meta
+++ b/ChillerUnityProject/Assets/Sprites/boilerRoom/Pipes_2.png.meta
@@ -31,7 +31,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: -1
+    filterMode: 0
     aniso: -1
     mipBias: -100
     wrapU: 1
@@ -42,7 +42,7 @@ TextureImporter:
   compressionQuality: 50
   spriteMode: 1
   spriteExtrude: 1
-  spriteMeshType: 1
+  spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 1
@@ -64,7 +64,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -76,7 +76,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0


### PR DESCRIPTION
Made changes on boiler room assets using the unity inspector, assets are no longer blurry and are the right colours

Also adjusted the boiler room door collider because it was off and moved some assets to their proper spots

Note: boiler is not interactable, i chose not to mess with it because I would probably would mess it up